### PR TITLE
TEST-004: Add automated E2E tests with --dry-run flag (Fixes #33)

### DIFF
--- a/provision-vm.sh
+++ b/provision-vm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ABOUTME: One-command VM provisioning script using Terraform and Ansible
-# Usage: ./provision-vm.sh <vm-name> [memory] [vcpus] [--test-dotfiles <path>]
+# Usage: ./provision-vm.sh <vm-name> [memory] [vcpus] [--test-dotfiles <path>] [--dry-run]
 
 set -e
 
@@ -22,15 +22,19 @@ while [[ $# -gt 0 ]]; do
         --test-dotfiles)
             if [ -z "${2:-}" ]; then
                 echo -e "${RED}[ERROR] --test-dotfiles flag requires a path argument${NC}" >&2
-                echo "Usage: $0 <vm-name> [memory] [vcpus] [--test-dotfiles <path>]" >&2
+                echo "Usage: $0 <vm-name> [memory] [vcpus] [--test-dotfiles <path>] [--dry-run]" >&2
                 exit 1
             fi
             DOTFILES_LOCAL_PATH="$2"
             shift 2
             ;;
+        --dry-run)
+            TEST_MODE=1
+            shift
+            ;;
         -*)
             echo -e "${RED}[ERROR] Unknown flag: $1${NC}" >&2
-            echo "Usage: $0 <vm-name> [memory] [vcpus] [--test-dotfiles <path>]" >&2
+            echo "Usage: $0 <vm-name> [memory] [vcpus] [--test-dotfiles <path>] [--dry-run]" >&2
             exit 1
             ;;
         *)
@@ -426,9 +430,9 @@ else
 fi
 echo ""
 
-# Exit early in test mode (after validation but before VM creation)
+# Exit early in test mode or dry-run (after validation but before VM creation)
 if [ "$TEST_MODE" = "1" ]; then
-    echo -e "${YELLOW}[TEST MODE] Validation complete, skipping VM creation${NC}"
+    echo -e "${YELLOW}[DRY RUN] Validation complete, skipping VM creation${NC}"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
Adds automated end-to-end (E2E) tests to verify the complete validation pipeline. Implements --dry-run flag for user-facing dry-run capability.

**Reference**: Issue #33 (TEST-004)  
**Test Automation Score**: 7.5/10 → 9.0/10 ✅

---

## Changes Made

### 1. --dry-run Flag (User-Facing)
- Added CLI flag to provision-vm.sh for testing without VM creation
- Maps to existing TEST_MODE infrastructure
- Updated usage message to include --dry-run
- Changed message from "TEST MODE" to "DRY RUN" for clarity

### 2. E2E Test Functions
Added two automated E2E tests:
- `test_e2e_full_pipeline()`: Tests complete validation with local dotfiles
- `test_e2e_dry_run_with_default_dotfiles()`: Tests GitHub fallback behavior

### 3. Test Suite Updates
- Replaced manual E2E placeholder with automated tests
- Updated tests expecting "TEST MODE" to check for "DRY RUN"
- All 66 tests passing (64 existing + 2 new E2E tests)

---

## Test Results

```bash
========================================
Test Results Summary
========================================
Total tests run: 66
Passed: 66
Failed: 0

ALL TESTS PASSED!
```

**New Tests:**
- ✅ E2E: Full pipeline validation with local dotfiles
- ✅ E2E: Dry-run with GitHub default dotfiles

---

## Benefits

- ✅ **Automated E2E coverage** - Removes manual testing gap
- ✅ **CI/CD integration ready** - --dry-run for pipeline validation
- ✅ **User debugging tool** - Test configuration without VM creation
- ✅ **Test Automation score** - 7.5/10 → 9.0/10

---

## Usage Examples

### User-Facing Dry Run
```bash
# Test with local dotfiles (no VM created)
./provision-vm.sh test-vm --test-dotfiles /path/to/dotfiles --dry-run

# Test with default GitHub dotfiles
./provision-vm.sh test-vm --dry-run
```

### Test Suite
```bash
# Run full test suite (includes E2E tests)
./tests/test_local_dotfiles.sh
```

---

## Related Issues
- Fixes #33 (TEST-004: Add automated E2E test)
- Builds on #46 (TEST-003: Replace grep tests with behavior tests)

---

## Ready for Review Checklist
- [x] --dry-run flag implemented
- [x] E2E tests added and passing
- [x] All 66 tests passing
- [x] Pre-commit hooks satisfied
- [x] Documentation updated (usage message)