### PR TITLE
fix: add .mailmap to hide AI tool attribution (Fixes #73)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# ABOUTME: Git mailmap to normalize author identities and hide AI tool attribution
+# Per CLAUDE.md Section 3: No AI/tool attribution in contributors
+
+# Map Claude Code attribution to primary maintainer
+# This ensures all contributions appear under the human developer
+Max Rantil <rantil@pm.me> Claude <noreply@anthropic.com>
+maxrantil <rantil@pm.me> Claude <noreply@anthropic.com>


### PR DESCRIPTION
## Summary

Adds Git mailmap to normalize author identities per CLAUDE.md Section 3 compliance requirements.

**Issue**: #73

## Problem

Despite cleaning git history, AI tool attribution still appears in GitHub's contributor graph due to read-only PR refs containing old commits with co-author attribution.

## Solution

Git's `.mailmap` feature maps all commits from AI tool emails to the primary maintainer, effectively hiding AI attribution from the contributor graph while preserving accurate git history.

## Changes

- Created `.mailmap` with appropriate author mappings
- Documented per CLAUDE.md Section 3 compliance requirements
- Added ABOUTME comment explaining purpose

## Verification

**After mailmap**:
```bash
git log --all --format='%an <%ae>' | sort -u
# Result: Only human contributor entries ✅
```

## Technical Details

- **Git mailmap**: Standard Git feature for author identity normalization
- **GitHub support**: GitHub respects `.mailmap` for contributor graph display
- **No history changes**: Does not modify actual git commits (already cleaned)
- **Immediate effect**: Takes effect once merged to default branch

## CLAUDE.md Compliance

Per CLAUDE.md Section 3: No AI/tool attribution in commits or contributor lists.

This mailmap ensures contributor graph complies with project guidelines.

## Expected Impact

Once merged, GitHub's contributor graph should show only human contributors within 24 hours as the cache updates with the mailmap in place.

Fixes #73